### PR TITLE
Updates to support building on darwin

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,8 @@
 if [ "$1" = "--torque" ]; then
     export CGO_CFLAGS='-DTORQUE -I/usr/include/torque'
 else
-    export CGO_LDFLAGS="-L$SGE_ROOT/lib/lx-amd64/"
+    export ARCH=`$SGE_ROOT/util/arch`
+    export CGO_LDFLAGS="-L$SGE_ROOT/lib/$ARCH/"
     export CGO_CFLAGS="-I$SGE_ROOT/include"
 fi
 

--- a/drmaa.go
+++ b/drmaa.go
@@ -70,6 +70,9 @@ import (
  #include <stdio.h>
  #include <stdlib.h>
  #include <stddef.h>
+#if __APPLE__
+ #include <unistd.h>
+#endif
  #include "drmaa.h"
 
 static char* makeString(size_t size) {

--- a/examples/simplearrayjob/build.sh
+++ b/examples/simplearrayjob/build.sh
@@ -7,7 +7,8 @@
 if [ "$1" = "--torque" ]; then
     export CGO_CFLAGS='-DTORQUE -I/usr/include/torque'
 else
-    export CGO_LDFLAGS="-L$SGE_ROOT/lib/lx-amd64/"
+    export ARCH=`$SGE_ROOT/util/arch`
+    export CGO_LDFLAGS="-L$SGE_ROOT/lib/$ARCH/"
     export CGO_CFLAGS="-I$SGE_ROOT/include"
 fi
 

--- a/examples/simplegestatus/build.sh
+++ b/examples/simplegestatus/build.sh
@@ -7,7 +7,8 @@
 if [ "$1" = "--torque" ]; then
     export CGO_CFLAGS='-DTORQUE -I/usr/include/torque'
 else
-    export CGO_LDFLAGS="-L$SGE_ROOT/lib/lx-amd64/"
+    export ARCH=`$SGE_ROOT/util/arch`
+    export CGO_LDFLAGS="-L$SGE_ROOT/lib/$ARCH/"
     export CGO_CFLAGS="-I$SGE_ROOT/include"
 fi
 

--- a/examples/simplesubmit/build.sh
+++ b/examples/simplesubmit/build.sh
@@ -7,7 +7,8 @@
 if [ "$1" = "--torque" ]; then
     export CGO_CFLAGS='-DTORQUE -I/usr/include/torque'
 else
-    export CGO_LDFLAGS="-L$SGE_ROOT/lib/lx-amd64/"
+    export ARCH=`$SGE_ROOT/util/arch`
+    export CGO_LDFLAGS="-L$SGE_ROOT/lib/$ARCH/"
     export CGO_CFLAGS="-I$SGE_ROOT/include"
 fi
 


### PR DESCRIPTION
This commit adds support for using the `arch` script from UGE to determine library paths and adds `unistd.h` on MacOS builds in order to provide the `gid_t` definition.