### PR TITLE
Support for Slurm

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,15 @@
 
 if [ "$1" = "--torque" ]; then
     export CGO_CFLAGS='-DTORQUE -I/usr/include/torque'
+elif [ "$1" = "--slurm" ]; then
+    export CGO_CFLAGS='-DSLURM'
+    if [ -n "$2" ]; then
+	SLURM_RDMAA_ROOT=$2
+    fi
+    if [ -n "$SLURM_DRMAA_ROOT" ]; then
+	export CGO_LDFLAGS="-L$SLURM_DRMAA_ROOT/lib"
+	export CGO_CFLAGS="-DSLURM -I$SLURM_DRMAA_ROOT/include"
+    fi
 else
     if [ "$SGE_ROOT" = "" ]; then
         echo "source your Grid Engine settings.(c)sh file"

--- a/drmaa.go
+++ b/drmaa.go
@@ -98,10 +98,18 @@ static void freeStringArray(char **a, const int size) {
 }
 
 int _drmaa_get_num_attr_values(drmaa_attr_values_t* values, int *size) {
-#ifdef TORQUE
+#if defined(TORQUE) || defined(SLURM)
     return drmaa_get_num_attr_values(values, (size_t *) size);
 #else
     return drmaa_get_num_attr_values(values, size);
+#endif
+}
+
+int _drmaa_get_num_attr_names(drmaa_attr_names_t* names, int *size) {
+#if defined(TORQUE) || defined(SLURM)
+    return drmaa_get_num_attr_names(names, (size_t *) size);
+#else
+    return drmaa_get_num_attr_names(names, size);
 #endif
 }
 */
@@ -569,7 +577,7 @@ func (s *Session) getAttributeNames(vectorAttributes bool) ([]string, error) {
 	// the size is not really required but a good test if that
 	// method is implemented in the underlying C DRMAA library
 	var size C.int
-	errNumber = C.drmaa_get_num_attr_names(vector, &size)
+	errNumber = C._drmaa_get_num_attr_names(vector, &size)
 	if errNumber != C.DRMAA_ERRNO_SUCCESS {
 		ce := makeError(C.GoString(diag), errorID[errNumber])
 		return nil, &ce

--- a/drmaa.go
+++ b/drmaa.go
@@ -97,7 +97,7 @@ static void freeStringArray(char **a, const int size) {
    free(a);
 }
 
-int _drmaa_get_num_attr_values(drmaa_attr_values_t* values, int *size) {
+static int _drmaa_get_num_attr_values(drmaa_attr_values_t* values, int *size) {
 #if defined(TORQUE) || defined(SLURM)
     return drmaa_get_num_attr_values(values, (size_t *) size);
 #else
@@ -105,7 +105,7 @@ int _drmaa_get_num_attr_values(drmaa_attr_values_t* values, int *size) {
 #endif
 }
 
-int _drmaa_get_num_attr_names(drmaa_attr_names_t* names, int *size) {
+static int _drmaa_get_num_attr_names(drmaa_attr_names_t* names, int *size) {
 #if defined(TORQUE) || defined(SLURM)
     return drmaa_get_num_attr_names(names, (size_t *) size);
 #else


### PR DESCRIPTION
I did the following modification in order to support SLURM. 
It is based on the last stable release of [PSNC DRMAA](http://apps.man.poznan.pl/trac/slurm-drmaa).

Apparently the TORQUE binding have similar issues `drmaa_get_num_attr_values(drmaa_attr_values_t* values, int *size)` VS `drmaa_get_num_attr_values(drmaa_attr_values_t* values, size_t *size)`.
I have the same issue with `drmaa_get_num_attr_names` and applied the same treatment, but I do not have torque available.
