### PR TITLE
Support alternate DRMAA location

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,7 +4,22 @@
 # of your Grid Engine installation before building. "default" is the CELL name, which can
 # be different in your installation.
 
-if [ "$1" = "--torque" ]; then
+if [ "$1" = "--drmaa" ]; then
+    if [ -z "$2" ]
+    then
+	echo "usage: $0 --drmaa <drmaa root>"
+	exit 1
+    else
+	if [ -d $2 ]
+	then 
+	    export CGO_LDFLAGS="-L$2/lib"
+	    export CGO_CFLAGS="-I$2/include"
+	else
+	    echo "$2 does not exist or is not a directory."
+	    exit 1
+	fi
+    fi
+elif [ "$1" = "--torque" ]; then
     export CGO_CFLAGS='-DTORQUE -I/usr/include/torque'
 else
     if [ "$SGE_ROOT" = "" ]; then


### PR DESCRIPTION
There was no way to specify an alternate drmaa location independently from the drmaa implementation selection.

Note that there is room for improvement. For one, this option could be provided in addition of the implementation selection.

As in:
```
./build.sh --drmaa <drmaa dir> --sge
```
also, if short options are ok, bash builtin [getopts](http://wiki.bash-hackers.org/howto/getopts_tutorial) could be used.